### PR TITLE
Update client_certificate documentation in admin API Lua file

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -1095,8 +1095,8 @@ return {
         },
         client_certificate = {
           description = [[
-            Certificate to be used as client certificate while TLS handshaking
-            to the upstream server.
+            If set, specifies the ID of the client certificate to be used during 
+            TLS handshaking with the upstream server.
           ]],
         },
         tls_verify = {
@@ -1923,7 +1923,8 @@ return {
         ["hash_on_uri_capture"] = { kind = "semi-optional", skip_in_example = true, description = [[The name of the route URI capture to take the value from as hash input. Only required when `hash_on` is set to `uri_capture`.]] },
         ["hash_fallback_uri_capture"] = { kind = "semi-optional", skip_in_example = true, description = [[The name of the route URI capture to take the value from as hash input. Only required when `hash_fallback` is set to `uri_capture`.]] },
         ["host_header"] = { description = [[The hostname to be used as `Host` header when proxying requests through Kong.]], example = "example.com", },
-        ["client_certificate"] = { description = [[If set, the certificate to be used as client certificate while TLS handshaking to the upstream server.]] },
+        ["client_certificate"] = { description = [[If set, specifies the ID of the client certificate to be used during TLS handshaking with the upstream server.]] },
+},
         ["use_srv_name"] = { description = [[If set, the balancer will use SRV hostname(if DNS Answer has SRV record) as the proxy upstream `Host`.]] },
         ["healthchecks.active.timeout"] = { description = [[Socket timeout for active health checks (in seconds).]] },
         ["healthchecks.active.concurrency"] = { description = [[Number of targets to check concurrently in active health checks.]] },


### PR DESCRIPTION
This commit updates the documentation for the `client_certificate` object in the admin API Lua file. The existing documentation suggested that an object should be sent with an `id` key, which caused confusion and inconsistencies when using the declarative configuration. However, through issue #8881 (link: https://github.com/Kong/kong/issues/8881), it was discovered that the `id` attribute is not required or supported in the declarative configuration. 

This update replaces the existing description and code snippets related to the `client_certificate` object with an updated description that reflects the correct behavior. The new description clarifies that if set, the `client_certificate` field specifies the ID of the client certificate to be used during TLS handshaking with the upstream server.

By making this change, we ensure that the documentation accurately represents the behavior of the `client_certificate` field and provides clear instructions to users. This resolves the issue reported by @meesvandongen on May 30, 2022, as documented in issue #8881.

Link to the issue: https://github.com/Kong/kong/issues/8881

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
